### PR TITLE
🐛 API V3: Set payload's timestamp when passed

### DIFF
--- a/src/V3/CategoriesController.php
+++ b/src/V3/CategoriesController.php
@@ -5,7 +5,7 @@
  *
  * @package Rhorber\Inventory\API\V3
  * @author  Raphael Horber
- * @version 05.08.2020
+ * @version 04.09.2020
  */
 namespace Rhorber\Inventory\API\V3;
 
@@ -19,7 +19,7 @@ use Rhorber\Inventory\API\Http;
  *
  * @package Rhorber\Inventory\API\V3
  * @author  Raphael Horber
- * @version 05.08.2020
+ * @version 04.09.2020
  */
 class CategoriesController
 {
@@ -161,7 +161,7 @@ class CategoriesController
      * @return  void
      * @access  public
      * @author  Raphael Horber
-     * @version 05.08.2020
+     * @version 04.09.2020
      */
     public function updateCategory(int $categoryId)
     {
@@ -174,9 +174,12 @@ class CategoriesController
             $currentStatement = $this->_database->prepareAndExecute($currentQuery, $currentParams);
             $currentTimestamp = $currentStatement->fetchColumn(0);
 
-            if ($payload['timestamp'] < $currentTimestamp) {
+            $timestamp = $payload['timestamp'];
+            if ($timestamp < $currentTimestamp) {
                 Http::sendNoContent();
             }
+        } else {
+            $timestamp = time();
         }
 
         $updateQuery  = "
@@ -188,7 +191,7 @@ class CategoriesController
         $updateParams = [
             ':id'        => $categoryId,
             ':name'      => $payload['name'],
-            ':timestamp' => time(),
+            ':timestamp' => $timestamp,
         ];
 
         $this->_database->prepareAndExecute($updateQuery, $updateParams);

--- a/src/V3/LotsController.php
+++ b/src/V3/LotsController.php
@@ -5,7 +5,7 @@
  *
  * @package Rhorber\Inventory\API\V3
  * @author  Raphael Horber
- * @version 05.08.2020
+ * @version 04.09.2020
  */
 namespace Rhorber\Inventory\API\V3;
 
@@ -24,7 +24,7 @@ use Rhorber\Inventory\API\Http;
  *
  * @package Rhorber\Inventory\API\V3
  * @author  Raphael Horber
- * @version 05.08.2020
+ * @version 04.09.2020
  */
 class LotsController
 {
@@ -72,7 +72,6 @@ class LotsController
         $position  = $maxStatement->fetchColumn(0);
         $timestamp = $payload['timestamp'] ?? time();
 
-
         $insertQuery  = "
             INSERT INTO lots (
                 article, best_before, stock, position, timestamp
@@ -100,7 +99,7 @@ class LotsController
      * @return  void
      * @access  public
      * @author  Raphael Horber
-     * @version 05.08.2020
+     * @version 04.09.2020
      */
     public function updateLot(int $lotId)
     {
@@ -113,9 +112,12 @@ class LotsController
             $currentStatement = $this->_database->prepareAndExecute($currentQuery, $currentParams);
             $currentTimestamp = $currentStatement->fetchColumn(0);
 
-            if ($payload['timestamp'] < $currentTimestamp) {
+            $timestamp = $payload['timestamp'];
+            if ($timestamp < $currentTimestamp) {
                 Http::sendNoContent();
             }
+        } else {
+            $timestamp = time();
         }
 
         $updateQuery  = "
@@ -129,7 +131,7 @@ class LotsController
             ':id'          => $lotId,
             ':best_before' => $payload['best_before'],
             ':stock'       => $payload['stock'],
-            ':timestamp'   => time(),
+            ':timestamp'   => $timestamp,
         ];
 
         $this->_database->prepareAndExecute($updateQuery, $updateParams);


### PR DESCRIPTION
When the same object is updated multiple times offline,
only the first update was made as the current timestamp was set.
Therefore, subsequent updates (made offline) were ignored,
because they seemed outdated.
This commit fixes this by setting the passed timestamp.